### PR TITLE
Add node 14 & 16 to the build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [12, 13]
+        node: [12, 14, 16]
 
     steps:
       - name: Checkout Repo


### PR DESCRIPTION
Currently js actions only support running against node 12 but at some point this will change so it's nice to know they at least build against these newer versions.