### PR TITLE
Move problem matcher to src folder

### DIFF
--- a/__tests__/problemMatcher.test.ts
+++ b/__tests__/problemMatcher.test.ts
@@ -1,12 +1,12 @@
 import { matchResults } from "../__helpers__/utils";
-import { problemMatcher as problemMatcherJson } from "../.github/problem-matcher.json";
+import { problemMatcher as problemMatcherJson } from "../src/problem-matcher.json";
 import { ProblemMatcher, ProblemPattern } from "github-actions-problem-matcher-typings";
 
 const problemMatcher: ProblemMatcher = problemMatcherJson[0];
 
 describe("problemMatcher", () => {
   it("has the correct owner", () => {
-    expect(problemMatcher.owner).toEqual("somelinter");
+    expect(problemMatcher.owner).toEqual("someLinter");
   });
 
   it("has one pattern", () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,7 @@ export async function run(): Promise<void> {
   try {
     const action = getInput("action");
 
-    const matcherFile = join(__dirname, "..", ".github", "problem-matcher.json");
+    const matcherFile = join(__dirname, "problem-matcher.json");
 
     switch (action) {
       case "add":

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,13 +1,12 @@
-import { readFile } from "fs";
+import { promises } from "fs";
 import { join } from "path";
-import { promisify } from "util";
 
 import { getInput, setFailed } from "@actions/core";
 import { issueCommand } from "@actions/core/lib/command"
 
 import { ProblemMatcherDocument } from "github-actions-problem-matcher-typings";
 
-const readFileAsync = promisify(readFile);
+const { readFile } = promises;
 
 export async function run(): Promise<void> {
   try {
@@ -25,7 +24,7 @@ export async function run(): Promise<void> {
         break;
 
       case "remove":
-        const fileContents = await readFileAsync(matcherFile, { encoding: "utf8" });
+        const fileContents = await readFile(matcherFile, { encoding: "utf8" });
         const problemMatcherDocument: ProblemMatcherDocument = JSON.parse(fileContents);
         const problemMatcher = problemMatcherDocument.problemMatcher[0];
 

--- a/src/problem-matcher.json
+++ b/src/problem-matcher.json
@@ -1,7 +1,7 @@
 {
   "problemMatcher": [
     {
-      "owner": "somelinter",
+      "owner": "someLinter",
       "pattern": [
         {
           "regexp": "^([^:]*):(\\d+):?(\\d+)?\\s+([\\w-\\/]*)\\s+(.*)$",


### PR DESCRIPTION
All [first party actions](https://github.com/actions) put their problem matcher files in the `.github` folder which is why I followed that pattern. Since then I've found it's better to keep them in the `src` folder with the rest of your code.